### PR TITLE
Delegation reward disabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 go 1.17
 
-module github.com/mande-labs/cosmos-sdk
+module github.com/cosmos/cosmos-sdk
 
 require (
 	github.com/99designs/keyring v1.1.6

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -164,14 +164,15 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val stakingtypes.Vali
 	// truncate coins, return remainder to community pool
 	coins, remainder := rewards.TruncateDecimal()
 
+	// disable delegation rewards for PoC
 	// add coins to user account
-	if !coins.IsZero() {
-		withdrawAddr := k.GetDelegatorWithdrawAddr(ctx, del.GetDelegatorAddr())
-		err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, coins)
-		if err != nil {
-			return nil, err
-		}
-	}
+	// if !coins.IsZero() {
+	// 	withdrawAddr := k.GetDelegatorWithdrawAddr(ctx, del.GetDelegatorAddr())
+	// 	err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, withdrawAddr, coins)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
 
 	// update the outstanding rewards and the community pool only if the
 	// transaction was successful

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -321,7 +321,7 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 	require.Equal(t, uint64(2), app.DistrKeeper.GetValidatorHistoricalReferenceCount(ctx))
 
 	// assert correct balance
-	exp := balanceTokens.Sub(valTokens).Add(initial.QuoRaw(2))
+	exp := balanceTokens.Sub(valTokens)
 	require.Equal(t,
 		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, exp)},
 		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(valAddrs[0])),
@@ -332,7 +332,7 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 	require.Nil(t, err)
 
 	// assert correct balance
-	exp = balanceTokens.Sub(valTokens).Add(initial)
+	exp = balanceTokens.Sub(valTokens).Add(initial.QuoRaw(2))
 	require.Equal(t,
 		sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, exp)},
 		app.BankKeeper.GetAllBalances(ctx, sdk.AccAddress(valAddrs[0])),


### PR DESCRIPTION
Commented out delegation rewards distribution.
Not removing the logic code because that involves removal of a whole lot functions and state records 